### PR TITLE
feat: Add multi-select for subscription batch operations

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -620,5 +620,83 @@
     "x_client_transaction_id_provider": "x-client-transaction-id provider",
     "@x_client_transaction_id_provider": {},
     "x_client_transaction_id_provider_description": "Set the x-client-transaction-id provider. It must be a domain name, without https. Reference: https://github.com/Teskann/x-client-transaction-id-generator",
-    "@x_client_transaction_id_provider_description": {}
+    "@x_client_transaction_id_provider_description": {},
+    "download": "Download",
+    "@download": {},
+    "download_tweet": "Download tweet",
+    "@download_tweet": {},
+    "download_this_tweet": "Download this tweet",
+    "@download_this_tweet": {},
+    "download_all_tweets": "Download all tweets",
+    "@download_all_tweets": {},
+    "download_settings": "Download Settings",
+    "@download_settings": {},
+    "download_mode": "Download Mode",
+    "@download_mode": {},
+    "download_mode_full_scan": "Full Scan",
+    "@download_mode_full_scan": {},
+    "download_mode_fast": "Fast (T=3)",
+    "@download_mode_fast": {},
+    "download_mode_safe": "Safe (T=20)",
+    "@download_mode_safe": {},
+    "download_started": "Download started...",
+    "@download_started": {},
+    "download_completed": "Download completed!",
+    "@download_completed": {},
+    "download_failed": "Download failed",
+    "@download_failed": {},
+    "api_server": "API Server",
+    "@api_server": {},
+    "about_download": "About",
+    "@about_download": {},
+    "about_download_description": "Download tweets using gallery-dl backend",
+    "@about_download_description": {},
+    "settings_saved": "Settings saved",
+    "@settings_saved": {},
+    "api_server_address": "API Server Address",
+    "@api_server_address": {},
+    "cancel": "Cancel",
+    "@cancel": {},
+    "save": "Save",
+    "@save": {},
+    "selected_count": "{count} selected",
+    "@selected_count": {
+      "placeholders": {
+        "count": {
+          "type": "int"
+        }
+      }
+    },
+    "select_all": "Select all",
+    "@select_all": {},
+    "deselect_all": "Deselect all",
+    "@deselect_all": {},
+    "invert_selection": "Invert selection",
+    "@invert_selection": {},
+    "batch_unsubscribe": "Batch Unsubscribe",
+    "@batch_unsubscribe": {},
+    "batch_unsubscribe_confirm": "Are you sure you want to unsubscribe from {count} users?",
+    "@batch_unsubscribe_confirm": {
+      "placeholders": {
+        "count": {
+          "type": "int"
+        }
+      }
+    },
+    "batch_add_to_group": "Batch Add to Group",
+    "@batch_add_to_group": {},
+    "batch_remove_from_feed": "Batch Remove from Feed",
+    "@batch_remove_from_feed": {},
+    "batch_remove_from_feed_confirm": "Are you sure you want to remove {count} users from the feed?",
+    "@batch_remove_from_feed_confirm": {
+      "placeholders": {
+        "count": {
+          "type": "int"
+        }
+      }
+    },
+    "select_groups": "Select Groups",
+    "@select_groups": {},
+    "confirm": "Confirm",
+    "@confirm": {}
 }

--- a/lib/l10n/intl_zh_Hans.arb
+++ b/lib/l10n/intl_zh_Hans.arb
@@ -654,5 +654,83 @@
     "x_client_transaction_id_provider": "x-client-transaction-id 提供者",
     "@x_client_transaction_id_provider": {},
     "x_client_transaction_id_provider_description": "设置 x-client-transaction-id 提供者。 它必须是域名，不带 https。参考：https://github.com/Teskann/x-client-transaction-id-generator",
-    "@x_client_transaction_id_provider_description": {}
+    "@x_client_transaction_id_provider_description": {},
+    "download": "下载",
+    "@download": {},
+    "download_tweet": "下载推文",
+    "@download_tweet": {},
+    "download_this_tweet": "下载此推文",
+    "@download_this_tweet": {},
+    "download_all_tweets": "下载所有推文",
+    "@download_all_tweets": {},
+    "download_settings": "下载设置",
+    "@download_settings": {},
+    "download_mode": "下载模式",
+    "@download_mode": {},
+    "download_mode_full_scan": "全量扫描",
+    "@download_mode_full_scan": {},
+    "download_mode_fast": "快速 (T=3)",
+    "@download_mode_fast": {},
+    "download_mode_safe": "稳健 (T=20)",
+    "@download_mode_safe": {},
+    "download_started": "下载已开始...",
+    "@download_started": {},
+    "download_completed": "下载完成！",
+    "@download_completed": {},
+    "download_failed": "下载失败",
+    "@download_failed": {},
+    "api_server": "API 服务器",
+    "@api_server": {},
+    "about_download": "关于",
+    "@about_download": {},
+    "about_download_description": "使用 gallery-dl 后端下载推文",
+    "@about_download_description": {},
+    "settings_saved": "设置已保存",
+    "@settings_saved": {},
+    "api_server_address": "API 服务器地址",
+    "@api_server_address": {},
+    "cancel": "取消",
+    "@cancel": {},
+    "save": "保存",
+    "@save": {},
+    "selected_count": "已选择 {count} 项",
+    "@selected_count": {
+      "placeholders": {
+        "count": {
+          "type": "int"
+        }
+      }
+    },
+    "select_all": "全选",
+    "@select_all": {},
+    "deselect_all": "取消全选",
+    "@deselect_all": {},
+    "invert_selection": "反选",
+    "@invert_selection": {},
+    "batch_unsubscribe": "批量取消订阅",
+    "@batch_unsubscribe": {},
+    "batch_unsubscribe_confirm": "确定要取消订阅 {count} 个用户吗？",
+    "@batch_unsubscribe_confirm": {
+      "placeholders": {
+        "count": {
+          "type": "int"
+        }
+      }
+    },
+    "batch_add_to_group": "批量添加到订阅组",
+    "@batch_add_to_group": {},
+    "batch_remove_from_feed": "批量从时间轴移除",
+    "@batch_remove_from_feed": {},
+    "batch_remove_from_feed_confirm": "确定要从时间轴移除 {count} 个用户吗？",
+    "@batch_remove_from_feed_confirm": {
+      "placeholders": {
+        "count": {
+          "type": "int"
+        }
+      }
+    },
+    "select_groups": "选择订阅组",
+    "@select_groups": {},
+    "confirm": "确认",
+    "@confirm": {}
 }

--- a/lib/subscriptions/_list.dart
+++ b/lib/subscriptions/_list.dart
@@ -1,16 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_triple/flutter_triple.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:multi_select_flutter/multi_select_flutter.dart';
 import 'package:pref/pref.dart';
+import 'package:provider/provider.dart';
 import 'package:squawker/constants.dart';
 import 'package:squawker/database/entities.dart';
+import 'package:squawker/generated/l10n.dart';
+import 'package:squawker/group/group_model.dart';
 import 'package:squawker/search/search.dart';
+import 'package:squawker/subscriptions/_groups.dart';
 import 'package:squawker/subscriptions/users_model.dart';
 import 'package:squawker/ui/errors.dart';
+import 'package:squawker/utils/data_service.dart';
+import 'package:squawker/utils/misc.dart';
 import 'package:squawker/utils/route_util.dart';
 import 'package:squawker/user.dart';
-import 'package:provider/provider.dart';
-import 'package:squawker/generated/l10n.dart';
 
 class SubscriptionUsers extends StatefulWidget {
   const SubscriptionUsers({Key? key}) : super(key: key);
@@ -79,6 +84,8 @@ class SubscriptionUsersList extends StatefulWidget {
 
 class SubscriptionUsersListState extends State<SubscriptionUsersList> {
   final List<Subscription> subLst = [];
+  bool _isMultiSelectMode = false;
+  final Set<String> _selectedIds = {};
 
   @override
   Widget build(BuildContext context) {
@@ -90,39 +97,317 @@ class SubscriptionUsersListState extends State<SubscriptionUsersList> {
     } else {
       subLst.addAll(widget.subscriptions);
     }
-    return ReorderableListView.builder(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        itemCount: subLst.length,
-        itemBuilder: (context, i) {
-          var user = subLst[i];
-          if (user is UserSubscription) {
-            return UserTile(key: Key(user.screenName), user: user);
-          }
 
-          return ListTile(
+    return Scaffold(
+      appBar: _isMultiSelectMode ? _buildMultiSelectAppBar(context) : null,
+      body: _buildBody(context, prefs),
+      bottomNavigationBar: _isMultiSelectMode ? _buildMultiSelectBottomBar(context) : null,
+    );
+  }
+
+  PreferredSizeWidget _buildMultiSelectAppBar(BuildContext context) {
+    final l10n = L10n.of(context);
+    return AppBar(
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        onPressed: _exitMultiSelectMode,
+      ),
+      title: Text(l10n.selected_count(_selectedIds.length)),
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.select_all),
+          tooltip: l10n.select_all,
+          onPressed: _selectAll,
+        ),
+        IconButton(
+          icon: const Icon(Icons.deselect),
+          tooltip: l10n.deselect_all,
+          onPressed: _deselectAll,
+        ),
+        IconButton(
+          icon: const Icon(Icons.flip),
+          tooltip: l10n.invert_selection,
+          onPressed: _invertSelection,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMultiSelectBottomBar(BuildContext context) {
+    final l10n = L10n.of(context);
+    final model = context.read<SubscriptionsModel>();
+    final groupModel = context.read<GroupsModel>();
+
+    return BottomAppBar(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          IconButton(
+            icon: const Icon(Symbols.person_remove_rounded, color: Colors.red),
+            tooltip: l10n.batch_unsubscribe,
+            onPressed: () => _batchUnsubscribe(context, model),
+          ),
+          IconButton(
+            icon: const Icon(Symbols.group_add_rounded),
+            tooltip: l10n.batch_add_to_group,
+            onPressed: () => _batchAddToGroup(context, groupModel),
+          ),
+          IconButton(
+            icon: const Icon(Symbols.person_remove_rounded),
+            tooltip: l10n.batch_remove_from_feed,
+            onPressed: () => _batchRemoveFromFeed(context, model),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody(BuildContext context, BasePrefService prefs) {
+    if (_isMultiSelectMode) {
+      return _buildMultiSelectList(context);
+    }
+
+    return ReorderableListView.builder(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: subLst.length,
+      itemBuilder: (context, i) {
+        var user = subLst[i];
+        if (user is UserSubscription) {
+          return UserTile(
             key: Key(user.screenName),
-            dense: true,
-            leading: const SizedBox(width: 48, child: Icon(Symbols.search_rounded)),
-            title: Text(user.name, maxLines: 1, overflow: TextOverflow.ellipsis),
-            subtitle: Text(L10n.current.search_term),
-            trailing: SizedBox(
-              width: 36,
-              child: FollowButton(user: user),
-            ),
-            onTap: () {
-              pushNamedRoute(context, routeSearch, SearchArguments(1, focusInputOnOpen: false, query: user.id));
-            },
+            user: user,
+            onLongPress: () => _enterMultiSelectMode(user.id),
           );
-        },
-        onReorder: (oldIndex, newIndex) async {
-          if (oldIndex < newIndex) {
-            Subscription s = subLst.removeAt(oldIndex);
-            subLst.insert(newIndex - 1, s);
-          } else {
-            Subscription s = subLst.removeAt(oldIndex);
-            subLst.insert(newIndex, s);
-          }
-          await prefs.set(optionSubscriptionOrderCustom, subLst.map((s) => s.screenName).join(','));
-        });
+        }
+
+        return ListTile(
+          key: Key(user.screenName),
+          dense: true,
+          leading: const SizedBox(width: 48, child: Icon(Symbols.search_rounded)),
+          title: Text(user.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+          subtitle: Text(L10n.current.search_term),
+          trailing: SizedBox(
+            width: 36,
+            child: FollowButton(user: user),
+          ),
+          onTap: () {
+            pushNamedRoute(context, routeSearch, SearchArguments(1, focusInputOnOpen: false, query: user.id));
+          },
+        );
+      },
+      onReorder: (oldIndex, newIndex) async {
+        if (oldIndex < newIndex) {
+          Subscription s = subLst.removeAt(oldIndex);
+          subLst.insert(newIndex - 1, s);
+        } else {
+          Subscription s = subLst.removeAt(oldIndex);
+          subLst.insert(newIndex, s);
+        }
+        await prefs.set(optionSubscriptionOrderCustom, subLst.map((s) => s.screenName).join(','));
+      },
+    );
+  }
+
+  Widget _buildMultiSelectList(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: subLst.length,
+      itemBuilder: (context, i) {
+        var user = subLst[i];
+        var isSelected = _selectedIds.contains(user.id);
+
+        return ListTile(
+          key: Key(user.screenName),
+          dense: true,
+          leading: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Checkbox(
+                value: isSelected,
+                onChanged: (value) => _toggleSelection(user.id),
+              ),
+              if (user is UserSubscription)
+                UserAvatar(uri: user.profileImageUrlHttps)
+              else
+                const SizedBox(width: 48, child: Icon(Symbols.search_rounded)),
+            ],
+          ),
+          title: Row(
+            children: [
+              Flexible(child: Text(user.name, maxLines: 1, overflow: TextOverflow.ellipsis)),
+              if (user is UserSubscription && user.verified) const SizedBox(width: 6),
+              if (user is UserSubscription && user.verified) Icon(Symbols.verified, size: 14, color: Theme.of(context).primaryColor)
+            ],
+          ),
+          subtitle: Text('@${user.screenName}', maxLines: 1, overflow: TextOverflow.ellipsis),
+          onTap: () => _toggleSelection(user.id),
+        );
+      },
+    );
+  }
+
+  void _enterMultiSelectMode(String initialId) {
+    setState(() {
+      _isMultiSelectMode = true;
+      _selectedIds.clear();
+      _selectedIds.add(initialId);
+    });
+  }
+
+  void _exitMultiSelectMode() {
+    setState(() {
+      _isMultiSelectMode = false;
+      _selectedIds.clear();
+    });
+  }
+
+  void _toggleSelection(String id) {
+    setState(() {
+      if (_selectedIds.contains(id)) {
+        _selectedIds.remove(id);
+        if (_selectedIds.isEmpty) {
+          _isMultiSelectMode = false;
+        }
+      } else {
+        _selectedIds.add(id);
+      }
+    });
+  }
+
+  void _selectAll() {
+    setState(() {
+      _selectedIds.clear();
+      _selectedIds.addAll(subLst.map((s) => s.id));
+    });
+  }
+
+  void _deselectAll() {
+    setState(() {
+      _selectedIds.clear();
+    });
+  }
+
+  void _invertSelection() {
+    setState(() {
+      final allIds = subLst.map((s) => s.id).toSet();
+      final newSelection = allIds.difference(_selectedIds);
+      _selectedIds.clear();
+      _selectedIds.addAll(newSelection);
+    });
+  }
+
+  List<Subscription> _getSelectedSubscriptions() {
+    return subLst.where((s) => _selectedIds.contains(s.id)).toList();
+  }
+
+  Future<void> _batchUnsubscribe(BuildContext context, SubscriptionsModel model) async {
+    final l10n = L10n.of(context);
+    final selected = _getSelectedSubscriptions();
+
+    if (selected.isEmpty) return;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.batch_unsubscribe),
+        content: Text(l10n.batch_unsubscribe_confirm(selected.length)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(l10n.cancel),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+            child: Text(l10n.unsubscribe),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      for (var user in selected) {
+        var followed = true; // We're unsubscribing, so they must be followed
+        await model.toggleSubscribe(user, followed);
+      }
+      _exitMultiSelectMode();
+    }
+  }
+
+  Future<void> _batchAddToGroup(BuildContext context, GroupsModel groupModel) async {
+    final l10n = L10n.of(context);
+    final selected = _getSelectedSubscriptions();
+
+    if (selected.isEmpty) return;
+
+    final selectedIds = selected.map((s) => s.id).toSet();
+
+    dynamic resp = 'reload';
+    while (resp is String && resp == 'reload') {
+      resp = await showDialog(
+        context: context,
+        builder: (_) => MultiSelectDialog(
+          title: Row(
+            children: [
+              Text(l10n.select_groups),
+              const Spacer(),
+              IconButton(
+                icon: const Icon(Symbols.add),
+                onPressed: () async {
+                  await openSubscriptionGroupDialog(context, null, '', defaultGroupIcon, preMembers: selectedIds);
+                  Navigator.pop(context, 'reload');
+                },
+              ),
+            ],
+          ),
+          searchHint: l10n.search,
+          confirmText: Text(l10n.ok),
+          cancelText: Text(l10n.cancel),
+          itemsTextStyle: Theme.of(context).textTheme.bodyLarge,
+          selectedColor: Theme.of(context).colorScheme.secondary,
+          items: groupModel.state.map((e) => MultiSelectItem(e.id, e.name)).toList(),
+          initialValue: [],
+          onConfirm: (List<dynamic> memberships) async {
+            for (var id in selectedIds) {
+              await groupModel.saveUserGroupMembership(id, memberships.cast<String>());
+            }
+          },
+        ),
+      );
+    }
+
+    _exitMultiSelectMode();
+  }
+
+  Future<void> _batchRemoveFromFeed(BuildContext context, SubscriptionsModel model) async {
+    final l10n = L10n.of(context);
+    final selected = _getSelectedSubscriptions().whereType<UserSubscription>().where((u) => u.inFeed).toList();
+
+    if (selected.isEmpty) return;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.batch_remove_from_feed),
+        content: Text(l10n.batch_remove_from_feed_confirm(selected.length)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(l10n.cancel),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(l10n.confirm),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      for (var user in selected) {
+        await model.toggleFeed(user, true);
+      }
+      _exitMultiSelectMode();
+    }
   }
 }

--- a/lib/user.dart
+++ b/lib/user.dart
@@ -81,8 +81,9 @@ class UserAvatar extends StatelessWidget {
 
 class UserTile extends StatelessWidget {
   final Subscription user;
+  final VoidCallback? onLongPress;
 
-  const UserTile({Key? key, required this.user}) : super(key: key);
+  const UserTile({Key? key, required this.user, this.onLongPress}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -104,6 +105,7 @@ class UserTile extends StatelessWidget {
       onTap: () {
         pushNamedRoute(context, routeProfile, ProfileScreenArguments(user.id, user.screenName));
       },
+      onLongPress: onLongPress,
     );
   }
 }


### PR DESCRIPTION
## Feature

Add multi-select mode to subscription list for batch operations.

## Usage

| Action | Description |
|--------|-------------|
| Long press | Enter multi-select mode |
| Tap | Toggle selection |
| AppBar buttons | Select all / Deselect all / Invert selection |
| BottomAppBar | Batch unsubscribe / Add to group / Remove from feed |

## Changes

### `lib/subscriptions/_list.dart`
- Add multi-select state management (`_isMultiSelectMode`, `_selectedIds`)
- Build multi-select AppBar with selection controls
- Build multi-select BottomAppBar with batch operation buttons
- Add checkbox list for selection UI
- Implement batch operations:
  - `_batchUnsubscribe()`: Unsubscribe from all selected users
  - `_batchAddToGroup()`: Add selected users to subscription group
  - `_batchRemoveFromFeed()`: Remove selected users from feed

### `lib/user.dart`
- Add `onLongPress` callback parameter to `UserTile`

### `lib/l10n/intl_en.arb`
- Add English translations for multi-select UI

### `lib/l10n/intl_zh_Hans.arb`
- Add Chinese translations for multi-select UI